### PR TITLE
fix: skip service start on usb

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,3 +93,4 @@
     name: docker
     enabled: yes
     state: started
+  tags: usb


### PR DESCRIPTION
Skip service restarts when creating a USB images as you cant restart services during this phase